### PR TITLE
limit to ENTER keypress only

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ demo-magic.sh is a handy shell script that enables you to script repeatable demo
 ## Functions
 
 ### pe
-Print and Execute. This function will simulate typing whatever you give it. It will then pause until you press a key. After your keypress it will run the command.
+Print and Execute. This function will simulate typing whatever you give it. It will then pause until you press <kbd>ENTER</kbd>. After your keypress it will run the command.
 
 ```bash
 #!/bin/bash
@@ -19,7 +19,7 @@ pe "ls -l"
 ```
 
 ### p
-Print only. This function will simulate typing whatever you give it. It will not run the command. After typing it will pause until you press a key. After your keypress it will move on to the next instruction in your script.
+Print only. This function will simulate typing whatever you give it. It will not run the command. After typing it will pause until you press <kbd>ENTER</kbd>. After your keypress it will move on to the next instruction in your script.
 
 ```bash
 #!/bin/bash
@@ -28,7 +28,7 @@ p "ls -l"
 ```
 
 ### wait
-Waits for the user to press any key.
+Waits for the user to press <kbd>ENTER</kbd>.
 
 ```bash
 #!/bin/bash
@@ -57,7 +57,7 @@ Then use the handy functions to run through your demo.
 
 ## Command line usage
 demo-magic.sh exposes 2 options out of the box to your script.
-- -d - disable simulated typing. Useful for debuging
+- -d - disable simulated typing. Useful for debugging
 - -h - prints the usage text
 
 ```bash

--- a/demo-magic.sh
+++ b/demo-magic.sh
@@ -7,7 +7,7 @@
 # Copyright (c) 2015 Paxton Hare
 #
 # This script lets you script demos in bash. It runs through your demo script when you press
-# a key. It simulates typing and runs commands.
+# ENTER. It simulates typing and runs commands.
 #
 ###############################################################################
 
@@ -39,10 +39,10 @@ function usage() {
 }
 
 ##
-# wait for user to press any key
+# wait for user to press ENTER
 ##
 function wait() {
-  read -rsn 1;
+  read -rs;
 }
 
 ##
@@ -60,7 +60,7 @@ function p() {
   x=$(PS1="$DEMO_PROMPT" "$BASH" --norc -i </dev/null 2>&1 | sed -n '${s/^\(.*\)exit$/\1/p;}')
   printf "$x"
 
-  # wait for the user to press a key before typing the command
+  # wait for the user to press ENTER before typing the command
   wait
 
   if [[ -z $TYPE_SPEED ]]; then
@@ -69,7 +69,7 @@ function p() {
     echo -en "\033[0m$cmd" | pv -qL $[$TYPE_SPEED+(-2 + RANDOM%5)];
   fi
 
-  # wait for the user to press a key before moving on
+  # wait for the user to press ENTER before moving on
   wait
   echo ""
 }


### PR DESCRIPTION
`read -rsn 1` expects a keypress that produce 1 character only. But e.g. arrow or function keys can produce several characters, so `wait` will not actually do its job.

This PR fixes that, requiring always to use <kbd>ENTER</kbd>.