### PR TITLE
OPTIONS : Add `no-wait` option after print or print-execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ clear
 Then use the handy functions to run through your demo.
 
 ## Command line usage
-demo-magic.sh exposes 2 options out of the box to your script.
+demo-magic.sh exposes 3 options out of the box to your script.
 - -d - disable simulated typing. Useful for debuging
 - -h - prints the usage text
+- -n - set no default waiting after `p` and `pe` functions
 
 ```bash
 $ ./my-demo.sh -h
@@ -68,6 +69,7 @@ Usage: ./my-demo.sh [options]
   Where options is one or more of:
   -h  Prints Help text
   -d  Debug mode. Disables simulated typing
+  -n  No wait
 
 ```
 
@@ -102,3 +104,26 @@ cat node-modules-install.log
 # now type and run the command to start your app
 pe "node index.js"
 ```
+
+### No waiting
+The -n _no wait_ option can be useful if you want to print and execute multiple commands.
+
+```bash
+# include demo-magic
+. ~/Desktop/Git/src/demo-magic/demo-magic.sh -n
+
+# add multiple commands
+pe 'git status'
+pe 'git log --oneline --decorate -n 20'
+```bash
+However this will oblige you to define your waiting points manually e.g.
+```bash
+...
+# define waiting points
+pe 'git status'
+pe 'git log --oneline --decorate -n 20'
+wait
+pe 'git pull'
+pe 'git log --oneline --decorate -n 20'
+wait
+```bash

--- a/demo-magic.sh
+++ b/demo-magic.sh
@@ -14,6 +14,9 @@
 # the speed to "type" the text
 TYPE_SPEED=20
 
+# no wait after "p" or "pe"
+NO_WAIT=false
+
 # handy color vars for pretty prompts
 BLACK="\033[0;30m"
 BLUE="\033[0;34m"
@@ -61,7 +64,9 @@ function p() {
   printf "$x"
 
   # wait for the user to press a key before typing the command
-  wait
+  if !($NO_WAIT); then
+    wait
+  fi
 
   if [[ -z $TYPE_SPEED ]]; then
     echo -en "\033[0m$cmd"
@@ -70,7 +75,9 @@ function p() {
   fi
 
   # wait for the user to press a key before moving on
-  wait
+  if !($NO_WAIT); then
+    wait
+  fi
   echo ""
 }
 
@@ -114,7 +121,7 @@ check_pv
 # -h for help
 # -d for disabling simulated typing
 #
-while getopts ":dh" opt; do
+while getopts ":dhn" opt; do
   case $opt in
     h)
       usage
@@ -122,6 +129,9 @@ while getopts ":dh" opt; do
       ;;
     d)
       unset TYPE_SPEED
+      ;;
+    n)
+      NO_WAIT=true
       ;;
   esac
 done


### PR DESCRIPTION
Hi Paxton,

I have come across your tool some months ago, when I was preparing for my [presentation on Git](https://prezi.com/p/hizdjq48bdqc/). Your demo-magic helped me to prepare my examples beforehand in order to have exactly the scenario I needed, and I was able to show the subject in the pace I needed, without any syntactical or semantical error. Top notch :+1: 

My examples included multiple bash commands, so I have introduced the notion of `no_wait` to be able to run for ex. two commands in one go. I have added it as an option, and I have declared my waiting points manually.

```
# including demo-magic
. ~/Desktop/Git/src/demo-magic/demo-magic.sh -n

# including manual waiting point
wait
```

I propose it for inclusion, if you like the idea.

Regards,

Ziggy.