### PR TITLE
Introduces prompt timeout (-w)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,19 @@ p "ls -l"
 ### wait
 Waits for the user to press <kbd>ENTER</kbd>.
 
+If `PROMPT_TIMEOUT` is defined and > 0 the demo will automatically proceed after the amount of seconds has passed.
+
 ```bash
 #!/bin/bash
 
+# Will wait until user presses enter
+PROMPT_TIMEOUT=0
 wait
+
+# Will wait max 5 seconds until user presses
+PROMPT_TIMEOUT=5
+wait
+
 ```
 
 ### cmd
@@ -65,9 +74,10 @@ Then use the handy functions to run through your demo.
 
 ## Command line usage
 demo-magic.sh exposes 3 options out of the box to your script.
-- -d - disable simulated typing. Useful for debugging
-- -h - prints the usage text
-- -n - set no default waiting after `p` and `pe` functions
+- `-d` - disable simulated typing. Useful for debugging
+- `-h` - prints the usage text
+- `-n` - set no default waiting after `p` and `pe` functions
+- `-w` - set no wait timeout after `p` and `pe` functions
 
 ```bash
 $ ./my-demo.sh -h
@@ -78,7 +88,7 @@ Usage: ./my-demo.sh [options]
   -h  Prints Help text
   -d  Debug mode. Disables simulated typing
   -n  No wait
-
+  -w  Waits max the given amount of seconds before proceeding with demo (e.g. `-w5`)
 ```
 
 ## Useful Tricks
@@ -118,12 +128,13 @@ The -n _no wait_ option can be useful if you want to print and execute multiple 
 
 ```bash
 # include demo-magic
-. ~/Desktop/Git/src/demo-magic/demo-magic.sh -n
+. demo-magic.sh -n
 
 # add multiple commands
 pe 'git status'
 pe 'git log --oneline --decorate -n 20'
-```bash
+```
+
 However this will oblige you to define your waiting points manually e.g.
 ```bash
 ...

--- a/demo-magic.sh
+++ b/demo-magic.sh
@@ -17,6 +17,9 @@ TYPE_SPEED=20
 # no wait after "p" or "pe"
 NO_WAIT=false
 
+# if > 0, will pause for this amount of seconds before automatically proceeding with any p or pe
+PROMPT_TIMEOUT=0
+
 # handy color vars for pretty prompts
 BLACK="\033[0;30m"
 BLUE="\033[0;34m"
@@ -44,9 +47,14 @@ function usage() {
 
 ##
 # wait for user to press ENTER
+# if $PROMPT_TIMEOUT > 0 this will be used as the max time for proceeding automatically
 ##
 function wait() {
-  read -rs;
+  if [[ "$PROMPT_TIMEOUT" == "0" ]]; then
+    read -rs
+  else
+    read -rst "$PROMPT_TIMEOUT"
+  fi
 }
 
 ##
@@ -139,7 +147,7 @@ check_pv
 # -h for help
 # -d for disabling simulated typing
 #
-while getopts ":dhn" opt; do
+while getopts ":dhnw:" opt; do
   case $opt in
     h)
       usage
@@ -151,5 +159,7 @@ while getopts ":dhn" opt; do
     n)
       NO_WAIT=true
       ;;
+    w)
+      PROMPT_TIMEOUT=$OPTARG
   esac
 done


### PR DESCRIPTION
I love this script! Also the recent addition (#3) was helpful. For my feeling the pace though was too much. I wanted to create a fully automated demo which requires the user not to press enter, but have a more natural flow.

I added a new option `-w` and the var `PROMPT_TIMEOUT`.

This will wait 1 second at every `pe` and `p`:
```bash
demo.sh -w1
```

In combination with the `-n` option and the `wait` function custom timeouts can be set anywhere in the script:

```bash
PROMPT_TIMEOUT=5
wait
```