### PR TITLE
fixes example execution

### DIFF
--- a/demo-magic.sh
+++ b/demo-magic.sh
@@ -42,7 +42,7 @@ function usage() {
   echo -e "\t-h\tPrints Help text"
   echo -e "\t-d\tDebug mode. Disables simulated typing"
   echo -e "\t-n\tNo wait"
-  echo -e "\t-w\tWaits max the given amount of seconds before proceeding with demo (e.g. `-w5`)"
+  echo -e "\t-w\tWaits max the given amount of seconds before proceeding with demo (e.g. '-w5')"
   echo -e ""
 }
 


### PR DESCRIPTION
```bash
$ demo.sh --help

Usage: demo.sh [options]

	Where options is one or more of:
	-h	Prints Help text
	-d	Debug mode. Disables simulated typing
	-n	No wait
demo-magic.sh: line 45: -w5: command not found
	-w	Waits max the given amount of seconds before proceeding with demo (e.g. )
```