### PR TITLE
Add options for demo prompt, command color and comment color

### DIFF
--- a/demo-magic.sh
+++ b/demo-magic.sh
@@ -37,6 +37,10 @@ COLOR_RESET="\033[0m"
 
 C_NUM=0
 
+# prompt and command color which can be overriden
+DEMO_PROMPT="$ "
+DEMO_CMD_COLOR=WHITE
+
 ##
 # prints the script usage
 ##
@@ -91,9 +95,9 @@ function p() {
   fi
 
   if [[ -z $TYPE_SPEED ]]; then
-    echo -en "\033[0m$cmd"
+    echo -en "$DEMO_CMD_COLOR$cmd$COLOR_RESET"
   else
-    echo -en "\033[0m$cmd" | pv -qL $[$TYPE_SPEED+(-2 + RANDOM%5)];
+    echo -en "$DEMO_CMD_COLOR$cmd$COLOR_RESET" | pv -qL $[$TYPE_SPEED+(-2 + RANDOM%5)];
   fi
 
   # wait for the user to press a key before moving on

--- a/demo-magic.sh
+++ b/demo-magic.sh
@@ -28,6 +28,7 @@ SHOW_CMD_NUMS=false
 BLACK="\033[0;30m"
 BLUE="\033[0;34m"
 GREEN="\033[0;32m"
+GREY="\033[0;90m"
 CYAN="\033[0;36m"
 RED="\033[0;31m"
 PURPLE="\033[0;35m"
@@ -39,7 +40,8 @@ C_NUM=0
 
 # prompt and command color which can be overriden
 DEMO_PROMPT="$ "
-DEMO_CMD_COLOR=WHITE
+DEMO_CMD_COLOR=$WHITE
+DEMO_COMMENT_COLOR=$GREY
 
 ##
 # prints the script usage
@@ -77,7 +79,11 @@ function wait() {
 #
 ##
 function p() {
-  cmd=$1
+  if [[ ${1:0:1} == "#" ]]; then
+    cmd=$DEMO_COMMENT_COLOR$1$COLOR_RESET
+  else
+    cmd=$DEMO_CMD_COLOR$1$COLOR_RESET
+  fi
 
   # render the prompt
   x=$(PS1="$DEMO_PROMPT" "$BASH" --norc -i </dev/null 2>&1 | sed -n '${s/^\(.*\)exit$/\1/p;}')
@@ -95,9 +101,9 @@ function p() {
   fi
 
   if [[ -z $TYPE_SPEED ]]; then
-    echo -en "$DEMO_CMD_COLOR$cmd$COLOR_RESET"
+    echo -en "$cmd"
   else
-    echo -en "$DEMO_CMD_COLOR$cmd$COLOR_RESET" | pv -qL $[$TYPE_SPEED+(-2 + RANDOM%5)];
+    echo -en "$cmd" | pv -qL $[$TYPE_SPEED+(-2 + RANDOM%5)];
   fi
 
   # wait for the user to press a key before moving on


### PR DESCRIPTION
This PR introduces three variables...

```bash
DEMO_PROMPT="$ "
DEMO_CMD_COLOR=$WHITE
DEMO_COMMENT_COLOR=$GREY
```

Which can be overriden for demos e.g.

```bash
# Include the demoing code
. demo-magic.sh
clear

# Set some options
DEMO_PROMPT=$BLUE"$ "
DEMO_CMD_COLOR=$GREEN
```

Here's a demo using those settings

<a href="https://asciinema.org/a/pOHpxUqIVkGdA1dqu7bENyxZk?size=medium&cols=120&autoplay=1" target="_blank"><img src="https://asciinema.org/a/pOHpxUqIVkGdA1dqu7bENyxZk.svg" /></a>