### PR TITLE
Issue in ZSH

### DIFF
--- a/demo-magic.sh
+++ b/demo-magic.sh
@@ -85,7 +85,7 @@ function p() {
     cmd=$DEMO_CMD_COLOR$1$COLOR_RESET
   fi
 
-  # # render the prompt
+  # render the prompt
   x=$(PS1="$DEMO_PROMPT" "$BASH" --norc -i </dev/null 2>&1 | sed -n '${s/^\(.*\)exit$/\1/p;}')
   
   # show command number is selected

--- a/demo-magic.sh
+++ b/demo-magic.sh
@@ -85,7 +85,7 @@ function p() {
     cmd=$DEMO_CMD_COLOR$1$COLOR_RESET
   fi
 
-  # render the prompt
+  # # render the prompt
   x=$(PS1="$DEMO_PROMPT" "$BASH" --norc -i </dev/null 2>&1 | sed -n '${s/^\(.*\)exit$/\1/p;}')
   
   # show command number is selected
@@ -96,7 +96,7 @@ function p() {
   fi
 
   # wait for the user to press a key before typing the command
-  if !($NO_WAIT); then
+  if [[ ! $NO_WAIT ]]; then
     wait
   fi
 
@@ -107,7 +107,7 @@ function p() {
   fi
 
   # wait for the user to press a key before moving on
-  if !($NO_WAIT); then
+  if [[ ! $NO_WAIT ]]; then
     wait
   fi
   echo ""


### PR DESCRIPTION
Not sure if this is specific to ZSH, but when I attempt to use demo magic, the following is thrown: 
`p:18: invalid mode specification`
It is complaining about: 
`if !($NO_WAIT); then`
When I modify to the following, then it works as expected: 
`if [[ ! $NO_WAIT ]]; then`
I've tested this modification in both a ZSH and BASH shell and it works as expected.
