### PR TITLE
Use bold default color as command color

### DIFF
--- a/demo-magic.sh
+++ b/demo-magic.sh
@@ -33,14 +33,15 @@ CYAN="\033[0;36m"
 RED="\033[0;31m"
 PURPLE="\033[0;35m"
 BROWN="\033[0;33m"
-WHITE="\033[1;37m"
+WHITE="\033[0;37m"
+BOLD="\033[1m"
 COLOR_RESET="\033[0m"
 
 C_NUM=0
 
 # prompt and command color which can be overriden
 DEMO_PROMPT="$ "
-DEMO_CMD_COLOR=$WHITE
+DEMO_CMD_COLOR=$BOLD
 DEMO_COMMENT_COLOR=$GREY
 
 ##

--- a/samples/demo-template.sh
+++ b/samples/demo-template.sh
@@ -27,7 +27,7 @@
 #
 # see http://www.tldp.org/HOWTO/Bash-Prompt-HOWTO/bash-prompt-escape-sequences.html for escape sequences
 #
-DEMO_PROMPT="${GREEN}➜ ${CYAN}\W "
+DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 # text color
 # DEMO_CMD_COLOR=$BLACK


### PR DESCRIPTION
This pull request changes the command color from bold white to simply bold.

Currently, the choice of white leads to barely readable or even entirely unreadable output on light terminal themes.
The change instead simply uses bold font so that the text color depends on the terminal theme.
That way, assuming a sensible terminal configuration, a readable color is used.