### PR TITLE
Add Option to Show Command Without Waiting

### DIFF
--- a/demo-magic.sh
+++ b/demo-magic.sh
@@ -16,6 +16,8 @@ TYPE_SPEED=20
 
 # no wait after "p" or "pe"
 NO_WAIT=false
+# display command without waiting
+NO_WAIT_DISPLAY_CMD=false
 
 # if > 0, will pause for this amount of seconds before automatically proceeding with any p or pe
 PROMPT_TIMEOUT=0
@@ -98,7 +100,7 @@ function p() {
   fi
 
   # wait for the user to press a key before typing the command
-  if [ $NO_WAIT = false ]; then
+  if [ "$NO_WAIT" = false ] && [ "$NO_WAIT_DISPLAY_CMD" = false ]; then
     wait
   fi
 


### PR DESCRIPTION
Adds an option to show commands without having to press enter. This is useful for a few situations:

1. If you want to output an empty prompt at the end of a section before running `clear` and continuing
2. Always showing the commands without having to press enter extra times
3. Displaying a comment without advancing the demo

Empty prompt with "sections" example:

```bash
pe 'echo "hello world"'
NO_WAIT_DISPLAY_CMD=true p ''

clear -x

pe 'echo "hello Conference Name Here"'
NO_WAIT_DISPLAY_CMD=true p ''
```

Without `NO_WAIT_DISPLAY_CMD` you have to press enter twice to advance the demo.

Showing comments without advancing the demo example:

```bash
NO_WAIT_DISPLAY_CMD=true p '# You are working on adding a deals page to the website when:'
NO_WAIT=true p '# QA found a bug in production and needs it fixed ASAP!'
NO_WAIT=true p '# The social media link is incorrect'
pe 'echo "hello world"'
```
This would allow the first comment to be displayed right away, but would wait for you to press enter before displaying the reset of the comments and finally an empty prompt.



The original functionality is identical to how it worked before. If the user does not set this variable their demo will not change in any way.