### PR TITLE
Add Demo With Setup Steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ The `demo-template.sh` is a bit of a showcase of some of the features.
 
 The `remote-exec` folder is there to show you how to run demo-magic locally and on a remote server via ssh. This was created in response to [Issue #24](https://github.com/paxtonhare/demo-magic/issues/24)
 
+The `self-setup` folder shows how you can setup an environment before starting your demo.
+
 ## Command line usage
 demo-magic.sh exposes some options to your script.
 - `-d` - disable simulated typing. Useful for debugging

--- a/samples/self-setup/README.md
+++ b/samples/self-setup/README.md
@@ -1,0 +1,5 @@
+# Self Setup Demo
+
+This demo sets up a git environment before the demo begins so you can simulate working with an existing git repository. The demo deletes any old state before starting so it can be run multiple times without any manual setup or clean up.
+
+You can call `./demo.sh --reset` to run the setup without launching the demo. This is useful for for double checking the setup without having to exit out of the demo.

--- a/samples/self-setup/demo.sh
+++ b/samples/self-setup/demo.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+. ../../demo-magic.sh -d
+
+################################
+# Setup
+################################
+
+set -e
+
+rm -rf main
+
+mkdir main
+cd main
+git init
+git config user.name "Alex Mayer"
+git config user.email amayer@example.com
+git config pager.log false
+
+cat <<EOF > main.go
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}
+EOF
+
+git add main.go
+git commit --message 'Initial Commit'
+
+if [ "$1" = "--reset" ]; then
+  exit
+fi
+
+# hide the evidence
+clear
+
+################################
+# Demo
+################################
+
+pe 'cat main.go'
+pe 'sed -i "s/World/Demo Magic/" main.go'
+pe 'cat main.go'
+pe 'git add main.go'
+pe 'git commit --message "World -> Demo Magic"'
+pe 'git log'
+
+# run program if go is installed
+if command -v go > /dev/null; then
+  pe 'go run main.go'
+fi
+
+pe ''


### PR DESCRIPTION
Adds a demo that demonstrates how to configure an environment before starting the demo. The environment in the demo is a git repo, but it could be any environment, like writing or resetting a bunch of files to a specific state. It also demonstrates how to reset the demo every time it starts so it runs smoothly without needing manual steps before starting.